### PR TITLE
Update test-nextflow script to use new kumar-lab module definitions

### DIFF
--- a/test-nextflow.sh
+++ b/test-nextflow.sh
@@ -10,8 +10,8 @@
 cd /projects/kumar-lab/multimouse-pipeline/nextflow-code/
 
 # LOAD NEXTFLOW
-module use --append /projects/omics_share/meta/modules
-module load nextflow/24.04.4
+module use --append /projects/kumar-lab/meta/modules
+module load nextflow/stable
 
 # RUN TEST PIPELINE
 nextflow run main.nf \


### PR DESCRIPTION
This switches the example from using the omic_share module load for nextflow to the new kumar-lab module. 

Under the hood, it loads the amazon corretto version of openjdk (21.x by default).