### PR TITLE
Yoda 103 add retry with more resources

### DIFF
--- a/nextflow/configs/profiles/sumner2.config
+++ b/nextflow/configs/profiles/sumner2.config
@@ -231,8 +231,8 @@ process {
         // 0.5 * t_min + 10.5
         time = { ((0.5 * params.clip_duration / 30 / 60 + 10.5) * 1.5).toInteger() + '.sec' * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     withLabel: "r_fboli_predict" {
         cpus = 2
@@ -240,8 +240,8 @@ process {
         // 2.5 * t_min + 5
         time = { ((2.5 * params.clip_duration / 30 / 60 + 5) * 1.5).toInteger() + '.sec' * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     // Frailty Resources
     withLabel: "r_flexibility" {
@@ -251,8 +251,8 @@ process {
         // 0.6 * t_min + 30
         time = { ((0.6 * params.clip_duration / 30 / 60 + 30) * 1.5).toInteger() + '.sec' * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     withLabel: "r_rearpaw" {
         cpus = 1
@@ -260,8 +260,8 @@ process {
         memory = { ((0.0047 * params.clip_duration / 30 / 60 + 0.0801) * 1.5).toInteger() + '.GB' * task.attempt }
         time = { 10.min * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     // Gait Resources
     withLabel: "r_gait_h5" {
@@ -270,8 +270,8 @@ process {
         memory = { ((0.0009 * params.clip_duration / 30 / 60 + 0.727) * 1.5).toInteger() + '.GB' * task.attempt }
         time = { 10.min * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     withLabel: "r_gait_bin" {
         cpus = 1
@@ -279,8 +279,8 @@ process {
         memory = { ((0.000005 * params.clip_duration / 30 / 60 + 0.0095) * 1.5).toInteger() + '.GB' * task.attempt }
         time = { 5.min * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     // JABS Resources
     withLabel: "r_jabs_features" {
@@ -293,8 +293,8 @@ process {
         // 162 * t_min + 4.6 for 6 windows
         time = { ((162 * params.clip_duration / 30 / 60 + 4.6) * 2.5).toInteger() + '.sec' * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     withLabel: "r_jabs_classify" {
         // This equation was not scaled for number of classifiers
@@ -305,16 +305,16 @@ process {
         // 30 * t_min + 127 for 10 classifiers
         time = { ((30 * params.clip_duration / 30 / 60 + 127) * 2.5).toInteger() + '.sec' * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     withLabel: "r_jabs_tablegen" {
         cpus = 1
         memory = { 1.GB * task.attempt }
         time = { 5.min * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     withLabel: "r_jabs_heuristic" {
         // This equation was not scaled for number of classifiers
@@ -324,8 +324,8 @@ process {
         // 0.111 * t_min + 37 for 6 classifiers
         time = { ((0.111 * params.clip_duration / 30 / 60 + 37) * 1.5).toInteger() + '.sec' * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     withLabel: "r_jabs_table_convert" {
         cpus = 1
@@ -334,8 +334,8 @@ process {
         // High value in experiments was 1-minute for a 1-hr video
         time = { 20.min * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     // Single Mouse Resources
     withLabel: "r_single_seg" {
@@ -348,8 +348,8 @@ process {
         // 15 * t_min - 63
         time = { ((15 * params.clip_duration / 30 / 60 + 0) * 2.5).toInteger() + '.sec' * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     withLabel: "r_single_keypoints" {
         // Note: This process is run before the clipping (to find the mouse entering the arena)
@@ -359,16 +359,16 @@ process {
         memory = { 64.GB * task.attempt }
         time = { 6.hours * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     withLabel: "r_single_qc" {
         // This task scales with number of videos in the batch, but is still small
         cpus = 1
         memory = { 4.GB * task.attempt }
         time = { 20.min * task.attempt }
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     withLabel: "r_clip_video" {
         cpus = 2
@@ -377,8 +377,8 @@ process {
         // 19.8 * t_min + 52
         time = { ((19.8 * params.clip_duration / 30 / 60 + 52) * 2.5).toInteger() + '.sec' * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     // Static Object Resources
     // These do not scale with clip duration
@@ -387,24 +387,24 @@ process {
         memory = { 4.GB * task.attempt }
         time = { 10.min * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     withLabel: "r_food_hopper" {
         cpus = 2
         memory = { 4.GB * task.attempt }
         time = { 10.min * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     withLabel: "r_lixit" {
         cpus = 2
         memory = { 4.GB * task.attempt }
         time = { 10.min * task.attempt }
         array = 200
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     // Utility Resources
     withLabel: "r_util" {
@@ -412,15 +412,15 @@ process {
         memory = { 1.GB * task.attempt }
         time = { 5.min * task.attempt }
         array = 500
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
     withLabel: "r_gen_vid" {
         cpus = 1
         memory = { 1.GB * task.attempt }
         time = { 1.hours * task.attempt }
-        errorStrategy 'retry'
-        maxRetries 3
+        errorStrategy = 'retry'
+        maxRetries = 3
     }
 }
 


### PR DESCRIPTION
Adds:
* retry for most processes
 * retry will occur under any fail criteria (including canceling of jobs)
 * both time and ram requests will be scaled linearly per-retry
* maximum resources are assigned to not exceed and indefinitely sit in the queue