### PR TITLE
Fixing resource retry calculation for GENERATE_FLEXIBILITY_INDEX process

### DIFF
--- a/nextflow/configs/profiles/sumner2.config
+++ b/nextflow/configs/profiles/sumner2.config
@@ -247,9 +247,15 @@ process {
     withLabel: "r_flexibility" {
         cpus = 1
         // 0.0048 * t_min + 0.080
-        memory = { ((0.0048 * params.clip_duration / 30 / 60 + 0.08) * 1.5).toInteger() + '.GB' * task.attempt }
+        memory = {
+            def base_mb = Math.max(1024, ((0.0048 * params.clip_duration / 30 / 60 + 0.08) * 1.5 * 1024).toInteger())
+            return (base_mb * task.attempt).MB
+        }
         // 0.6 * t_min + 30
-        time = { ((0.6 * params.clip_duration / 30 / 60 + 30) * 1.5).toInteger() + '.sec' * task.attempt }
+        time = {
+            def base_min = Math.max(1, ((0.6 * params.clip_duration / 30 / 60 + 30) * 1.5 / 60).toInteger())
+            return (base_min * task.attempt).min
+        }
         array = 200
         errorStrategy = 'retry'
         maxRetries = 3


### PR DESCRIPTION
This PR stems from Jira ticket YODA-127.

While debugging, I was seeing the following lines in the nextflow config after the `GENERATE_FLEXIBILITY_INDEX` process failed:

```
DEBUG nextflow.Session - Session aborted -- Cause: Not a valid 'memory' value in process definition: 0.GB.GB
```

The process successfully retries and completes when using the resource definition for the `r_flexibility` label proposed in this PR. 

**Note** that this change does **not** fully resolve YODA-127.