### PR TITLE
Adding code to handle when prediction_matrix is None

### DIFF
--- a/mouse-tracking-runtime/tfs_inference/arena_corners.py
+++ b/mouse-tracking-runtime/tfs_inference/arena_corners.py
@@ -77,6 +77,8 @@ def infer_arena_corner_model(args):
 	corner_results.results_receiver_queue.put((None, None))
 	corner_matrix = corner_results.get_results()
 	try:
+		if corner_matrix is None:
+			raise ValueError("No corner predictions were generated")
 		filtered_corners = filter_square_keypoints(corner_matrix)
 		if args.out_file is not None:
 			write_static_object_data(args.out_file, filtered_corners, 'corners', model_definition['model-name'], model_definition['model-checkpoint'])

--- a/mouse-tracking-runtime/utils/prediction_saver.py
+++ b/mouse-tracking-runtime/utils/prediction_saver.py
@@ -130,7 +130,8 @@ class prediction_saver:
 				available_new_frames -= prediction_count
 				cur_mat_size = next_mat_size
 		# Clip out unused info from the matrices
-		prediction_matrix = prediction_matrix[:cur_frames_used_count]
+		if prediction_matrix is not None:
+			prediction_matrix = prediction_matrix[:cur_frames_used_count]
 		# Close down the dequeue thread
 		output_queue.put((prediction_matrix))
 


### PR DESCRIPTION
The PR handles the case when `PREDICT_ARENA_CORNERS` fails to return a prediction. This resulted in a `None` value for `prediction_matrix`, which was causing the pipeline to hang and eventually get killed by Slurm.

This PR adds logic to handle the `None` case so that the pipeline doesn't crash.

It **does not** fix whatever is causing `PREDICT_ARENA_CORNERS` to fail.