### PR TITLE
Add nextflow process to merge bout tables by behavior

### DIFF
--- a/nextflow/modules/jabs_classifiers.nf
+++ b/nextflow/modules/jabs_classifiers.nf
@@ -103,6 +103,17 @@ process BEHAVIOR_TABLE_TO_FEATURES {
     """
 }
 
+/**
+* Aggregate bout tables by behavior across all videos.
+*
+* This process uses jabs-postprocess to merge tables by behavior,
+* creating separate merged files for each behavior detected.
+*
+* @param bout_tables List of paths to bout tables to be merged.
+*
+* @return merged_bout_tables List of paths to merged bout tables, one per behavior.
+* @return merge_log Path to the log file detailing the merge process.
+*/
 process AGGREGATE_BOUT_TABLES {
     label "jabs_table_convert"
     label "r_jabs_table_convert"


### PR DESCRIPTION
Integrate JABS Behavior Table Merging

This PR integrates the new [JABS-postprocess](https://github.com/KumarLabJax/JABS-postprocess/pull/35) behavior table merging functionality into the SINGLE_MOUSE_V6_FEATURES workflow, enabling automatic consolidation of bout tables by behavior type for enhanced downstream analysis capabilities.

- Created a new `AGGREGATE_BOUT_TABLES` process
- Integrated `AGGREGATE_BOUT_TABLES` process into `SINGLE_MOUSE_V6_FEATURES` workflow