### PR TITLE
Adding in Leg_splaying classifier

### DIFF
--- a/nextflow/configs/profiles/sumner2.config
+++ b/nextflow/configs/profiles/sumner2.config
@@ -40,7 +40,7 @@ params {
     classifier_training_file_folder = "/projects/kumar-lab/multimouse-pipeline/nextflow-artifacts/training_files/"
     exported_classifier_folder = "/projects/kumar-lab/multimouse-pipeline/nextflow-artifacts/exported_classifiers/"
     classifier_artifact_suffix = "_classifier_v${jabs_version}.pickle"
-    classifier_window_sizes = [2, 5, 10, 20, 30, 60]
+    classifier_window_sizes = [2, 3, 5, 10, 20, 30, 60]
     // Classifiers are described as behavior_name: project_folder
     single_mouse_classifiers = [
         "grooming": [
@@ -53,11 +53,11 @@ params {
             "stitch_value": 5,
             "filter_value": 5,
         ],
-        // "Leg_splaying": [  // Currently can't be exported successfully
-        //     "project_folder_name": "ptz",
-        //     "stitch_value": 5,
-        //     "filter_value": 5,
-        // ],
+        "Leg_splaying": [
+            "project_folder_name": "ptz",
+            "stitch_value": 5,
+            "filter_value": 5,
+        ],
         "Side_seizure": [
             "project_folder_name": "ptz",
             "stitch_value": 5,


### PR DESCRIPTION
Adds Leg_splaying classifier to sumner2 config.

v0.34.3 of JABS resolved the feature calculation issue with this classifier, so it can now be included.
This classifier uses a window size of 3, so that now needs to be calculated in the cache.