### PR TITLE
Changing the folder where singularity copies models

### DIFF
--- a/vm/singularity.def
+++ b/vm/singularity.def
@@ -8,4 +8,4 @@ From: aberger4/mouse-tracking:python3.10-slim
     mkdir -p ${SINGULARITY_ROOTFS}/workspace/models/
 
 %files
-    ./models ${SINGULARITY_ROOTFS}/workspace/
+    ./models /workspace/


### PR DESCRIPTION
Patches a container build issue for where models were placed. The var was only needed for the `%setup` block, not `%files` block.

Before: `/${SINGULARITY_ROOTFS}/workspace/models`
After: `/workspace/models`