### PR TITLE
Bugfix/incorrect output handling merge tables

### DIFF
--- a/nextflow/modules/jabs_classifiers.nf
+++ b/nextflow/modules/jabs_classifiers.nf
@@ -178,12 +178,15 @@ process BEHAVIOR_TABLE_TO_FEATURES {
 *
 * @return merged_bout_tables List of paths to merged bout tables, one per behavior.
 * @return merge_log Path to the log file detailing the merge process.
+*
+* @publish ./results/merged_behavior_tables Merged behavior bout tables
+* @publish ./results/merged_behavior_tables Merge log file
 */
 process AGGREGATE_BOUT_TABLES {
     label "jabs_table_convert"
     label "r_jabs_table_convert"
 
-    publishDir "${params.outdir}/merged_behavior_tables", mode: 'copy'
+    publishDir "${params.pubdir}/merged_behavior_tables", mode: 'copy'
 
     input:
     path bout_tables

--- a/nextflow/workflows/feature_generation.nf
+++ b/nextflow/workflows/feature_generation.nf
@@ -46,6 +46,7 @@ include { EXTRACT_FECAL_BOLI_BINS } from "${projectDir}/nextflow/modules/fecal_b
  *
  * @return path gait_results The channel of generated gait feature files.
  * @return path morphometrics_results The channel of generated morphometric feature files.
+ * @return path merged_bout_tables The channel of merged bout tables from JABS classifiers.
  *
  * @publish ./results/ Gait feature files
  * @publish ./results/ Morphometric feature files
@@ -128,7 +129,7 @@ workflow SINGLE_MOUSE_V6_FEATURES {
         .map { bout_table, summary_table -> bout_table }
         .flatten()
         .collect()
-    merged_bout_tables = AGGREGATE_BOUT_TABLES(all_bout_tables)
+    merged_bout_tables = AGGREGATE_BOUT_TABLES(all_bout_tables).merged_bout_tables
 
     // Combine table data into feature file
     all_summary_tables = heuristic_tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mouse-tracking"
-version = "0.1.1"
+version = "0.1.2"
 description = "Runtime environment for mouse tracking experiments"
 requires-python = ">=3.10,<3.11"
 packages = ["src/mouse_tracking"]

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,7 @@ wheels = [
 
 [[package]]
 name = "mouse-tracking"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "absl-py" },


### PR DESCRIPTION
This change fixes the error reported by @michberger 

```
ERROR ~ Cannot emit a multi-channel output: merged_bout_tables
 -- Check script '/home/bergem/.nextflow/assets/KumarLabJax/mouse-tracking-runtime/main.nf' at line: 34 or see '.nextflow.log' file for more details
 ```
 
 It also fixes the incorrectly defined publishDir definition in `AGGREGATE_BOUT_TABLES` and updates the docstrings to properly reflect what `AGGREGATE_BOUT_TABLES` publishes and the returns of `SINGLE_MOUSE_V2_FEATURES`. 