### PR TITLE
Casting a potential string object to file to access baseName

### DIFF
--- a/nextflow/workflows/single_mouse_pipeline.nf
+++ b/nextflow/workflows/single_mouse_pipeline.nf
@@ -124,7 +124,7 @@ workflow SPLIT_BY_CORNERS {
 
     // Publish the pose files
     v6_poses_renamed = v6_with_corners.map { video, pose ->
-        tuple(pose, "results/${video.baseName.replace("%20", "/")}_pose_est_v6.h5")
+        tuple(pose, "results/${file(video).baseName.replace("%20", "/")}_pose_est_v6.h5")
     }
     PUBLISH_SM_POSE_V6(v6_poses_renamed)
     // Corners that failed are placed in a separate folder with url-ified names


### PR DESCRIPTION
Bug to fix first error reported by @michberger 
```
ERROR ~ No such variable: baseName
 -- Check script '/home/bergem/.nextflow/assets/KumarLabJax/mouse-tracking-runtime/nextflow/workflows/single_mouse_pipeline.nf' at line: 127 or see '.nextflow.log' file for more details
```