### PR TITLE
Update singularity image locations for sumner2

### DIFF
--- a/nextflow/configs/profiles/sumner2.config
+++ b/nextflow/configs/profiles/sumner2.config
@@ -192,16 +192,16 @@ process {
      * Runtime options
      */
     withLabel: "tracking" {
-        container = "/projects/kumar-lab/multimouse-pipeline/nextflow-containers/deployment-runtime_2025-08-26.sif"
+        container = "/projects/kumar-lab/meta/images/mouse-tracking-runtime/runtime/v0.1.2/latest.sif"
     }
     withLabel: "jabs_classify" {
-        container = "/projects/kumar-lab/multimouse-pipeline/nextflow-containers/JABS-GUI_2025-02-12_v0.18.1.sif"
+        container = "/projects/kumar-lab/meta/images/JABS-behavior-classifier/headless/v0.36.1/latest.sif"
     }
     withLabel: "jabs_postprocess" {
-        container = "/projects/kumar-lab/multimouse-pipeline/nextflow-containers/JABS-Postprocessing-2025-03-27_864d687.sif"
+        container = "/projects/kumar-lab/meta/images/JABS-postprocess/jabs-postprocess/v0.3.1/latest.sif"
     }
     withLabel: "jabs_table_convert" {
-        container = "/projects/kumar-lab/multimouse-pipeline/nextflow-containers/support-r-code_2025-02-11.sif"
+        container = "/projects/kumar-lab/meta/images/mouse-tracking-runtime/RBase/v0.1.2/latest.sif"
     }
     withLabel: "gait" {
         container = "/projects/kumar-lab/multimouse-pipeline/nextflow-containers/gait-pipeline-2025-03-27.sif"
@@ -210,10 +210,10 @@ process {
         container = "/projects/kumar-lab/multimouse-pipeline/nextflow-containers/vfi-2025-03-27.sif"
     }
     withLabel: "sleap" {
-        container = "/projects/kumar-lab/multimouse-pipeline/nextflow-containers/sleap-1.4.1.sif"
+        container = "/projects/kumar-lab/meta/images/mouse-tracking-runtime/sleap-1.4.1/v0.1.2/latest.sif"
     }
     withLabel: "sleap_io" {
-        container = "/projects/kumar-lab/multimouse-pipeline/nextflow-containers/sleap-io-0.2.0.sif"
+        container = "/projects/kumar-lab/meta/images/mouse-tracking-runtime/sleap-io-0.2.0/v0.1.2/latest.sif"
     }
     withLabel: "rclone" {
         // executor.queueSize = 1

--- a/vm/rclone.def
+++ b/vm/rclone.def
@@ -1,0 +1,6 @@
+from: rclone/rclone
+bootstrap: docker
+
+%post
+    apk add --no-cache bash
+


### PR DESCRIPTION
This PR updates the singularity image locations to reference the new meta/images image repository.

Before we merge this, I would like to check with @SkepticRaven about the `gait` `frailty` and `rclone` images.