### PR TITLE
Fix command calls in jabs_classifiers nextflow module

### DIFF
--- a/nextflow/modules/jabs_classifiers.nf
+++ b/nextflow/modules/jabs_classifiers.nf
@@ -106,7 +106,12 @@ process GENERATE_BEHAVIOR_TABLES {
     script:
     """
     behavior_command="--behavior ${classifiers.collect { entry -> "$entry.key --stitch_gap $entry.value.stitch_value --min_bout_length $entry.value.filter_value" }.join(' --behavior ')}"
-    python3 /JABS-postprocess/generate_behavior_tables.py --project_folder . --feature_folder . --out_prefix ${in_pose.baseName} --out_bin_size 5 \${behavior_command}
+    jabs-postprocess generate-tables \
+        --project_folder . \
+        --feature_folder . \
+        --out_prefix ${in_pose.baseName} \
+        --out_bin_size 5 \
+        \${behavior_command}
     """
 }
 
@@ -139,7 +144,12 @@ process PREDICT_HEURISTICS {
     """
     for classifier in ${heuristic_classifiers.join(' ')};
     do
-        python3 /JABS-postprocess/heuristic_classify.py --project_folder . --feature_folder . --behavior_config \${classifier} --out_prefix ${in_pose.baseName} --out_bin_size 5
+        jabs-postprocess heuristic-classify \
+            --project-folder . \
+            --feature-folder . \
+            --behavior-config \${classifier} \
+            --out-prefix ${in_pose.baseName} \
+            --out_bin_size 5
     done
     """
 }
@@ -211,7 +221,7 @@ process AGGREGATE_BOUT_TABLES {
     echo "Input tables found:" >> merge_log.txt
     ls table_staging/*.csv >> merge_log.txt
     
-    uv run python -m jabs_postprocess.cli.main merge-multiple-tables \\
+    jabs-postprocess merge-multiple-tables \\
         --table-folder table_staging \\
         --table-pattern "*_bouts.csv" \\
         --output-prefix merged \\
@@ -223,3 +233,4 @@ process AGGREGATE_BOUT_TABLES {
     ls merged_*_bouts_merged.csv >> merge_log.txt 2>/dev/null || echo "No merged files generated" >> merge_log.txt
     """
 }
+


### PR DESCRIPTION
This PR fixes the jabs-postprocess command calls from the `nextflow/modules/jabs_classifiers.nf` file to stay up to date with the changes to the jabs-postprocess image.