### PR TITLE
Fixing image locations for sumner2 gait and frailty images

### DIFF
--- a/nextflow/configs/profiles/sumner2.config
+++ b/nextflow/configs/profiles/sumner2.config
@@ -207,10 +207,10 @@ process {
         container = "/projects/kumar-lab/meta/images/mouse-tracking-runtime/RBase/v${params.image_version}/latest.sif"
     }
     withLabel: "gait" {
-        container = "/projects/kumar-lab/multimouse-pipeline/nextflow-containers/gait-pipeline-2025-03-27.sif"
+        container = "/projects/kumar-lab/meta/images/gait/v2025-03-27/latest.sif"
     }
     withLabel: "frailty" {
-        container = "/projects/kumar-lab/multimouse-pipeline/nextflow-containers/vfi-2025-03-27.sif"
+        container = "/projects/kumar-lab/meta/images/frailty/v2025-03-27/latest.sif"
     }
     withLabel: "sleap" {
         container = "/projects/kumar-lab/meta/images/mouse-tracking-runtime/sleap-1.4.1/v${params.image_version}/latest.sif"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mouse-tracking"
-version = "0.2.5"
+version = "0.2.6"
 description = "Runtime environment for mouse tracking experiments"
 requires-python = ">=3.10,<3.11"
 packages = ["src/mouse_tracking"]

--- a/uv.lock
+++ b/uv.lock
@@ -980,7 +980,7 @@ wheels = [
 
 [[package]]
 name = "mouse-tracking"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "absl-py" },


### PR DESCRIPTION
The images for frailty and gait were no longer in their legacy locations after our Tier 2 cleanup efforts. This fixes the references to point to the correct location for those two images.