### PR TITLE
Fix misleading _time_secs column name to _time_min

### DIFF
--- a/support_code/behavior_summaries.R
+++ b/support_code/behavior_summaries.R
@@ -29,7 +29,7 @@ data_agg <- lapply(seq_along(row_num), function(x) {
     tmp <- data |> group_by(MouseID) |> filter(row_number() <= row_num[x])
     tmpsum <- rowsum(tmp[,sapply(tmp, is.numeric)], tmp$MouseID)
     
-    tmpsum <- tmpsum |> mutate(!!paste0("bin_avg_", row_num[x]*5, ".", behavior, "_time_secs") := get(paste0(behavior, "_time_behavior"))/(get(paste0(behavior, "_time_behavior")) + get(paste0(behavior, "_time_not_behavior")))*row_num[x]*5, !!paste0("bin_avg_", row_num[x]*5, ".", behavior, "_distance_cm") := get(paste0(behavior, "_behavior_dist"))/(row_num[x]*5))
+    tmpsum <- tmpsum |> mutate(!!paste0("bin_avg_", row_num[x]*5, ".", behavior, "_time_min") := get(paste0(behavior, "_time_behavior"))/(get(paste0(behavior, "_time_behavior")) + get(paste0(behavior, "_time_not_behavior")))*row_num[x]*5, !!paste0("bin_avg_", row_num[x]*5, ".", behavior, "_distance_cm") := get(paste0(behavior, "_behavior_dist"))/(row_num[x]*5))
     
     tmpsum$MouseID <- rownames(tmpsum)
     tmpsum <- tmpsum |> select(!all_of(cols_to_exclude))

--- a/support_code/behavior_summaries.py
+++ b/support_code/behavior_summaries.py
@@ -141,9 +141,9 @@ def aggregate_data_by_bin_size(
     behavior_dist_col = f"{behavior}_behavior_dist"
     behavior_bout_col = f"{behavior}_bout_behavior"
 
-    # Calculate time spent in behavior
+    # Calculate time spent in behavior (in minutes)
     # TODO: Do we need to make `5` a configurable parameter?
-    aggregated[f"bin_sum_{bin_size * 5}.{behavior}_time_secs"] = (
+    aggregated[f"bin_sum_{bin_size * 5}.{behavior}_time_min"] = (
         aggregated[time_behavior_col]
         / (aggregated[time_behavior_col] + aggregated[time_not_behavior_col])
         * bin_size


### PR DESCRIPTION
## Summary

- Renamed the aggregated behavior time column from `_time_secs` to `_time_min` in both the Python (`behavior_summaries.py`) and R (`behavior_summaries.R`) implementations.
- The formula `proportion_of_behavior * bin_size * 5` produces a value in **minutes** (e.g. `bin_size=4` yields a 20-minute window scaled by the behavior proportion), but the column was labeled `_time_secs`, which is incorrect and misleading for downstream consumers.

## Details

**Files changed:**
- `support_code/behavior_summaries.py` — column renamed from `bin_sum_{n}.{behavior}_time_secs` to `bin_sum_{n}.{behavior}_time_min`
- `support_code/behavior_summaries.R` — column renamed from `bin_avg_{n}.{behavior}_time_secs` to `bin_avg_{n}.{behavior}_time_min`

**Breaking change:** Any downstream notebooks, scripts, or dashboards that reference columns like `bin_sum_20.grooming_time_secs` must update to `bin_sum_20.grooming_time_min`.

## Test plan

- [x] Ran full test suite: **2,302 passed**, 10 skipped, 0 failures
- [ ] Verify no downstream pipelines or analysis scripts reference the old `_time_secs` column name
- [ ] Confirm output CSV column names are correct after a pipeline run

Made with [Cursor](https://cursor.com)