### PR TITLE
Fix latency feature extraction

### DIFF
--- a/support_code/behavior_summaries.py
+++ b/support_code/behavior_summaries.py
@@ -131,6 +131,18 @@ def aggregate_data_by_bin_size(
     grouped = data.groupby("MouseID")
     filtered_data = pd.concat([group.iloc[:bin_size] for _, group in grouped])
 
+    # Extract latency values before summing. agg with a positional lambda
+    # preserves NaN (unlike first()/last() which skip NaN), returns a Series
+    # indexed by MouseID for correct alignment with aggregated.
+    latency_first_col = f"{behavior}_latency_to_first_prediction"
+    latency_last_col = f"{behavior}_latency_to_last_prediction"
+    latency_first = filtered_data.groupby("MouseID")[latency_first_col].agg(
+        lambda s: s.iloc[0]
+    )
+    latency_last = filtered_data.groupby("MouseID")[latency_last_col].agg(
+        lambda s: s.iloc[-1]
+    )
+
     # Aggregate numeric columns by summing them
     numeric_cols = filtered_data.select_dtypes(include=["number"]).columns
     aggregated = filtered_data.groupby("MouseID")[numeric_cols].sum()
@@ -181,10 +193,10 @@ def aggregate_data_by_bin_size(
     # TODO: var and std need to be aggregated across bins.
     # This is non-trivial because of the partial bouts and their associated weights.
     aggregated[f"bin_first_{bin_size * 5}.{behavior}_latency_first_prediction"] = (
-        aggregated[f"{behavior}_latency_to_first_prediction"].head(1)
+        latency_first
     )
     aggregated[f"bin_last_{bin_size * 5}.{behavior}_latency_last_prediction"] = (
-        aggregated[f"{behavior}_latency_to_last_prediction"].tail(1)
+        latency_last
     )
 
     # Reset index to make MouseID a regular column

--- a/tests/support_code/test_behavior_summaries.py
+++ b/tests/support_code/test_behavior_summaries.py
@@ -1,0 +1,132 @@
+"""Unit tests for support_code/behavior_summaries.py."""
+
+import math
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# behavior_summaries.py lives in support_code/, which is not a package.
+# Add it to sys.path so we can import it directly.
+sys.path.insert(0, str(Path(__file__).parents[2] / "support_code"))
+
+import behavior_summaries  # noqa: E402
+
+
+BEHAVIOR = "Jumping"
+
+
+def _make_filtered_data(
+    latency_first_values: list,
+    latency_last_values: list,
+    mouse_id: str = "mouse_A",
+) -> pd.DataFrame:
+    """Build a minimal per-bin DataFrame matching the shape expected by aggregate_data_by_bin_size."""
+    n = len(latency_first_values)
+    return pd.DataFrame(
+        {
+            "MouseID": [mouse_id] * n,
+            f"{BEHAVIOR}_latency_to_first_prediction": latency_first_values,
+            f"{BEHAVIOR}_latency_to_last_prediction": latency_last_values,
+            f"{BEHAVIOR}_time_behavior": [100.0] * n,
+            f"{BEHAVIOR}_time_not_behavior": [200.0] * n,
+            f"{BEHAVIOR}_behavior_dist": [50.0] * n,
+            f"{BEHAVIOR}_behavior_dist_threshold": [10.0] * n,
+            f"{BEHAVIOR}_behavior_dist_seg": [5.0] * n,
+            f"{BEHAVIOR}_bout_behavior": [2] * n,
+            f"{BEHAVIOR}_avg_bout_duration": [1.5] * n,
+            f"{BEHAVIOR}__stats_sample_count": [2] * n,
+            f"{BEHAVIOR}_bout_duration_std": [0.1] * n,
+            f"{BEHAVIOR}_bout_duration_var": [0.01] * n,
+        }
+    )
+
+
+class TestLatencyFirstPrediction:
+    def test_returns_first_bin_value_when_present(self):
+        """latency_first should be the first bin's value, not a cumulative sum."""
+        data = _make_filtered_data(
+            latency_first_values=[2506.0, 9412.0, 18082.0, float("nan")],
+            latency_last_values=[4900.0, 11000.0, 19000.0, float("nan")],
+        )
+        result = behavior_summaries.aggregate_data_by_bin_size(data, bin_size=4, behavior=BEHAVIOR)
+        col = f"bin_first_20.{BEHAVIOR}_latency_first_prediction"
+        assert result[col].iloc[0] == pytest.approx(2506.0)
+
+    def test_returns_nan_when_first_bin_has_no_behavior(self):
+        """latency_first should be NaN when the first bin has no behavior, not a later bin's value."""
+        data = _make_filtered_data(
+            latency_first_values=[float("nan"), 5000.0, 12000.0, float("nan")],
+            latency_last_values=[float("nan"), 8000.0, 15000.0, float("nan")],
+        )
+        result = behavior_summaries.aggregate_data_by_bin_size(data, bin_size=4, behavior=BEHAVIOR)
+        col = f"bin_first_20.{BEHAVIOR}_latency_first_prediction"
+        assert math.isnan(result[col].iloc[0])
+
+    def test_single_bin_returns_that_bins_value(self):
+        data = _make_filtered_data(
+            latency_first_values=[2506.0],
+            latency_last_values=[4900.0],
+        )
+        result = behavior_summaries.aggregate_data_by_bin_size(data, bin_size=1, behavior=BEHAVIOR)
+        col = f"bin_first_5.{BEHAVIOR}_latency_first_prediction"
+        assert result[col].iloc[0] == pytest.approx(2506.0)
+
+
+class TestLatencyLastPrediction:
+    def test_returns_last_bin_value_when_present(self):
+        """latency_last should be the last bin's value, not a cumulative sum."""
+        data = _make_filtered_data(
+            latency_first_values=[2506.0, 9412.0, 18082.0, 38222.0],
+            latency_last_values=[4900.0, 11000.0, 19000.0, 45000.0],
+        )
+        result = behavior_summaries.aggregate_data_by_bin_size(data, bin_size=4, behavior=BEHAVIOR)
+        col = f"bin_last_20.{BEHAVIOR}_latency_last_prediction"
+        assert result[col].iloc[0] == pytest.approx(45000.0)
+
+    def test_returns_nan_when_last_bin_has_no_behavior(self):
+        """latency_last should be NaN when the last bin has no behavior, not a previous bin's value."""
+        data = _make_filtered_data(
+            latency_first_values=[float("nan"), 5000.0, 12000.0, float("nan")],
+            latency_last_values=[float("nan"), 8000.0, 15000.0, float("nan")],
+        )
+        result = behavior_summaries.aggregate_data_by_bin_size(data, bin_size=4, behavior=BEHAVIOR)
+        col = f"bin_last_20.{BEHAVIOR}_latency_last_prediction"
+        assert math.isnan(result[col].iloc[0])
+
+    def test_single_bin_returns_that_bins_value(self):
+        data = _make_filtered_data(
+            latency_first_values=[2506.0],
+            latency_last_values=[4900.0],
+        )
+        result = behavior_summaries.aggregate_data_by_bin_size(data, bin_size=1, behavior=BEHAVIOR)
+        col = f"bin_last_5.{BEHAVIOR}_latency_last_prediction"
+        assert result[col].iloc[0] == pytest.approx(4900.0)
+
+
+class TestMultiMouseAlignment:
+    def test_each_mouse_gets_its_own_first_latency(self):
+        """With multiple mice, each should receive their own first-bin latency value."""
+        mouse_a = _make_filtered_data(
+            latency_first_values=[2506.0, 9412.0],
+            latency_last_values=[4900.0, 11000.0],
+            mouse_id="mouse_A",
+        )
+        mouse_b = _make_filtered_data(
+            latency_first_values=[float("nan"), 5000.0],
+            latency_last_values=[float("nan"), 8000.0],
+            mouse_id="mouse_B",
+        )
+        data = pd.concat([mouse_a, mouse_b], ignore_index=True)
+        result = behavior_summaries.aggregate_data_by_bin_size(data, bin_size=2, behavior=BEHAVIOR)
+        result = result.set_index("MouseID")
+
+        first_col = f"bin_first_10.{BEHAVIOR}_latency_first_prediction"
+        last_col = f"bin_last_10.{BEHAVIOR}_latency_last_prediction"
+
+        assert result.loc["mouse_A", first_col] == pytest.approx(2506.0)
+        assert math.isnan(result.loc["mouse_B", first_col])
+
+        assert result.loc["mouse_A", last_col] == pytest.approx(11000.0)
+        assert result.loc["mouse_B", last_col] == pytest.approx(8000.0)


### PR DESCRIPTION
# Fix: Latency First/Last Prediction Cumulative Sum Bug
## Summary
support_code/behavior_summaries.py
1. Before the `groupby().sum()`, the latency values are now extracted from the per-bin `filtered_data` using `agg(lambda s: s.iloc[0]) and agg(lambda s: s.iloc[-1])`. These return a Series indexed by MouseID, preserve NaN, and do not sum across bins.
2. The old `.head(1)` / `.tail(1)` calls (which operated on already-summed, post-groupby data) are replaced with direct assignment from these pre-computed Series.

tests/support_code/test_behavior_summaries.py — 7 new tests covering:
1. First bin with behavior → correct value returned
2. First bin without behavior → NaN (does not bleed from a later bin)
3. Last bin with behavior → correct value returned
4. Last bin without behavior → NaN (does not bleed from a prior bin)
5. Single-bin edge case
6. Multi-mouse correctness (each mouse gets its own values)

## Context
`bin_first_XX.{behavior}_latency_first_prediction` and `bin_last_XX.{behavior}_latency_last_prediction` in the output feature CSVs are wrong. Instead of reporting the latency to the first/last prediction within the analysis window, they report a cumulative sum of per-bin latency values. For example, for the video `041345_B6J_M_42462_trimmed.avi`:
- `bin_first_15.Jumping_latency_first_prediction` = 30000 (16.67 min) — outside the 0–15 min window
- `bin_first_60.Jumping_latency_first_prediction` = 256925 (142.7 min) — far outside the 0–60 min window

**The bug is in `support_code/behavior_summaries.py`.**

## Root Cause
In `support_code/behavior_summaries.py`, `aggregate_data_by_bin_size()` (line 117):

**Line 136** sums ALL numeric columns per MouseID, including the latency columns:
```python
aggregated = filtered_data.groupby("MouseID")[numeric_cols].sum()
```

This collapses `filtered_data` to one row per MouseID with latency values **summed across bins** (e.g., bins 0–5, 5–10, 10–15 each have a latency, and they get added together).

**Lines 183–188** then try to extract first/last from the already-collapsed result:
```python
aggregated[f"bin_first_{bin_size * 5}.{behavior}_latency_first_prediction"] = (
    aggregated[f"{behavior}_latency_to_first_prediction"].head(1)
)
aggregated[f"bin_last_{bin_size * 5}.{behavior}_latency_last_prediction"] = (
    aggregated[f"{behavior}_latency_to_last_prediction"].tail(1)
)
```

After the groupby, there is one row per MouseID. `.head(1)` returns only the **first mouse's** summed value — for a single-mouse run this silently produces the wrong (summed) number; for multi-mouse runs it also produces NaN for all mice except the first/last.

## What the Values Should Be
The per-bin `latency_to_first_prediction` values are absolute frame numbers from the start of the video (not relative to the bin start), so:
- `latency_first_prediction` for a window = the **first non-NaN** `latency_to_first_prediction` across all bins in that window per MouseID
- `latency_last_prediction` for a window = the **last non-NaN** `latency_to_last_prediction` across all bins in that window per MouseID

## Fix
**File:** `support_code/behavior_summaries.py`

In `aggregate_data_by_bin_size()`, before the `groupby().sum()` on line 136, extract the latency values from the per-bin `filtered_data` using `nth()`, which **preserves NaN** (unlike `first()`/`last()` which skip NaN and would carry a prior-bin value forward):

```python
latency_first_col = f"{behavior}_latency_to_first_prediction"
latency_last_col = f"{behavior}_latency_to_last_prediction"
latency_first = filtered_data.groupby("MouseID")[latency_first_col].nth(0)
latency_last = filtered_data.groupby("MouseID")[latency_last_col].nth(-1)
```

- `nth(0)` — returns the first bin's value per MouseID; if that bin has no behavior the result is NaN
- `nth(-1)` — returns the last bin's value per MouseID; if that bin has no behavior the result is NaN, rather than falling back to a previous bin's value

Then replace lines 183–188 with:
```python
aggregated[f"bin_first_{bin_size * 5}.{behavior}_latency_first_prediction"] = latency_first
aggregated[f"bin_last_{bin_size * 5}.{behavior}_latency_last_prediction"] = latency_last
```

Since both `aggregated` and `latency_first`/`latency_last` are indexed by MouseID after the respective groupby operations, pandas will align them correctly for all mice.

## Verification
No existing tests cover `behavior_summaries.py`. After the fix, add a pytest test in `tests/` (or `support_code/tests/`) that:

1. Constructs a small synthetic per-bin DataFrame for two mice with 4 bins each:
   - Mouse A: latency_first bins = [2506, 9412, NaN, 38222]; latency_last bins = [4900, 11000, NaN, 45000]
   - Mouse B: latency_first bins = [NaN, 5000, 12000, NaN]; latency_last bins = [NaN, 8000, 15000, NaN]
2. Calls `aggregate_data_by_bin_size()` with `bin_size=4`
3. Asserts for `latency_first_prediction` (first bin's value):
   - Mouse A == 2506 (first bin has behavior)
   - Mouse B == NaN (first bin has no behavior — must NOT fall back to 5000)
4. Asserts for `latency_last_prediction` (last bin's value):
   - Mouse A == 45000 (last bin has behavior)
   - Mouse B == NaN (last bin has no behavior — must NOT fall back to 15000 from the previous bin)
